### PR TITLE
Extend servant-docs to support content types

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,13 @@ import Servant
 data Greet = Greet { _msg :: Text }
   deriving (Generic, Show)
 
--- we get our JSON serialization for free
+-- we get our JSON serialization for free. This will be used by the default
+-- 'MimeRender' instance for 'JSON'.
 instance FromJSON Greet
 instance ToJSON Greet
 
--- we can render a Greeting into JSON using this ToJSON instance
-instance MimeRender JSON Greet where
-    toByteString Proxy = encodePretty
-
--- or we can render it to HTML
-instance MimeRender HTML Greet where
+-- We can also implement 'MimeRender' explicitly for additional formats.
+instance MimeRender PlainText Greet where
     toByteString Proxy (Greet s) = "<h1>" <> cs s <> "</h1>"
 
 -- we provide a sample value for the 'Greet' type
@@ -59,7 +56,7 @@ instance ToCapture (Capture "greetid" Text) where
 
 -- API specification
 type TestApi =
-       "hello" :> Capture "name" Text :> QueryParam "capital" Bool :> Get '[JSON,HTML] Greet
+       "hello" :> Capture "name" Text :> QueryParam "capital" Bool :> Get '[JSON,PlainText] Greet
   :<|> "greet" :> RQBody '[JSON] Greet :> Post '[JSON] Greet
   :<|> "delete" :> Capture "greetid" Text :> Delete
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ data Greet = Greet { _msg :: Text }
 instance FromJSON Greet
 instance ToJSON Greet
 
+-- we can render a Greeting into JSON using this ToJSON instance
+instance MimeRender JSON Greet where
+    toByteString Proxy = encodePretty
+
+-- or we can render it to HTML
+instance MimeRender HTML Greet where
+    toByteString Proxy (Greet s) = "<h1>" <> cs s <> "</h1>"
+
 -- we provide a sample value for the 'Greet' type
 instance ToSample Greet where
   toSample = Just g
@@ -51,8 +59,8 @@ instance ToCapture (Capture "greetid" Text) where
 
 -- API specification
 type TestApi =
-       "hello" :> Capture "name" Text :> QueryParam "capital" Bool :> Get Greet
-  :<|> "greet" :> RQBody Greet :> Post Greet
+       "hello" :> Capture "name" Text :> QueryParam "capital" Bool :> Get '[JSON,HTML] Greet
+  :<|> "greet" :> RQBody '[JSON] Greet :> Post '[JSON] Greet
   :<|> "delete" :> Capture "greetid" Text :> Delete
 
 testApi :: Proxy TestApi

--- a/example/greet.hs
+++ b/example/greet.hs
@@ -8,9 +8,8 @@
 import Data.Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Proxy
+import Data.String.Conversions
 import Data.Text (Text)
-import qualified Data.Text.Lazy as T
-import qualified Data.Text.Lazy.Encoding as T
 import GHC.Generics
 import Servant.API
 import Servant.API.ContentTypes
@@ -26,12 +25,10 @@ instance FromJSON Greet
 instance ToJSON Greet
 
 instance MimeRender JSON Greet where
-    toByteString Proxy v = encodePretty v
+    toByteString Proxy = encodePretty
 
 instance MimeRender HTML Greet where
-    toByteString Proxy (Greet s) = "<h1>" <> (c s) <> "</h1>"
-      where
-        c = T.encodeUtf8 . T.fromStrict
+    toByteString Proxy (Greet s) = "<h1>" <> cs s <> "</h1>"
 
 -- We add some useful annotations to our captures,
 -- query parameters and request body to make the docs

--- a/example/greet.hs
+++ b/example/greet.hs
@@ -12,7 +12,6 @@ import Data.String.Conversions
 import Data.Text (Text)
 import GHC.Generics
 import Servant.API
-import Servant.API.ContentTypes
 import Servant.Docs
 
 -- * Example

--- a/example/greet.hs
+++ b/example/greet.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE TypeOperators         #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 import Data.Aeson
-import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Proxy
 import Data.String.Conversions
 import Data.Text (Text)
@@ -20,16 +19,14 @@ import Servant.Docs
 newtype Greet = Greet Text
   deriving (Generic, Show)
 
+-- | We can get JSON support automatically. This will be used to parse
+-- and encode a Greeting as 'JSON'.
 instance FromJSON Greet
 instance ToJSON Greet
 
--- | A 'Greet' value can be rendered to 'JSON'.
-instance MimeRender JSON Greet where
-    toByteString Proxy = encodePretty
-
--- | A 'Greet' value can be rendered to 'HTML'.
-instance MimeRender HTML Greet where
-    toByteString Proxy (Greet s) = "<h1>" <> cs s <> "</h1>"
+-- | We can also implement 'MimeRender' for additional formats like 'PlainText'.
+instance MimeRender PlainText Greet where
+    toByteString Proxy (Greet s) = "\"" <> cs s <> "\""
 
 -- We add some useful annotations to our captures,
 -- query parameters and request body to make the docs
@@ -76,8 +73,8 @@ intro2 = DocIntro "This title is below the last"
 
 -- API specification
 type TestApi =
-       -- GET /hello/:name?capital={true, false}  returns a Greet as JSON or HTML
-       "hello" :> MatrixParam "lang" String :> Capture "name" Text :> QueryParam "capital" Bool :> Get '[JSON, HTML] Greet
+       -- GET /hello/:name?capital={true, false}  returns a Greet as JSON or PlainText
+       "hello" :> MatrixParam "lang" String :> Capture "name" Text :> QueryParam "capital" Bool :> Get '[JSON, PlainText] Greet
 
        -- POST /greet with a Greet as JSON in the request body,
        --             returns a Greet as JSON

--- a/example/greet.hs
+++ b/example/greet.hs
@@ -23,9 +23,11 @@ newtype Greet = Greet Text
 instance FromJSON Greet
 instance ToJSON Greet
 
+-- | A 'Greet' value can be rendered to 'JSON'.
 instance MimeRender JSON Greet where
     toByteString Proxy = encodePretty
 
+-- | A 'Greet' value can be rendered to 'HTML'.
 instance MimeRender HTML Greet where
     toByteString Proxy (Greet s) = "<h1>" <> cs s <> "</h1>"
 
@@ -74,12 +76,12 @@ intro2 = DocIntro "This title is below the last"
 
 -- API specification
 type TestApi =
-       -- GET /hello/:name?capital={true, false}  returns a Greet as JSON
+       -- GET /hello/:name?capital={true, false}  returns a Greet as JSON or HTML
        "hello" :> MatrixParam "lang" String :> Capture "name" Text :> QueryParam "capital" Bool :> Get '[JSON, HTML] Greet
 
        -- POST /greet with a Greet as JSON in the request body,
        --             returns a Greet as JSON
-  :<|> "greet" :> ReqBody '[JSON,HTML] Greet :> Post '[JSON] Greet
+  :<|> "greet" :> ReqBody '[JSON] Greet :> Post '[JSON] Greet
 
        -- DELETE /greet/:greetid
   :<|> "greet" :> Capture "greetid" Text :> Delete

--- a/example/greet.hs
+++ b/example/greet.hs
@@ -66,11 +66,11 @@ intro2 = DocIntro "This title is below the last"
 -- API specification
 type TestApi =
        -- GET /hello/:name?capital={true, false}  returns a Greet as JSON
-       "hello" :> MatrixParam "lang" String :> Capture "name" Text :> QueryParam "capital" Bool :> Get Greet
+       "hello" :> MatrixParam "lang" String :> Capture "name" Text :> QueryParam "capital" Bool :> Get '[JSON] Greet
 
        -- POST /greet with a Greet as JSON in the request body,
        --             returns a Greet as JSON
-  :<|> "greet" :> ReqBody Greet :> Post Greet
+  :<|> "greet" :> ReqBody '[JSON] Greet :> Post '[JSON] Greet
 
        -- DELETE /greet/:greetid
   :<|> "greet" :> Capture "greetid" Text :> Delete

--- a/servant-docs.cabal
+++ b/servant-docs.cabal
@@ -29,14 +29,12 @@ library
   build-depends:
       base >=4.7 && <5
     , aeson
-    , aeson-pretty < 0.8
     , bytestring
     , hashable
     , http-media
     , lens
     , servant >= 0.2.1
     , string-conversions
-    , system-filepath
     , text
     , unordered-containers
   hs-source-dirs: src

--- a/servant-docs.cabal
+++ b/servant-docs.cabal
@@ -45,5 +45,5 @@ executable greet-docs
   main-is: greet.hs
   hs-source-dirs: example
   ghc-options: -Wall
-  build-depends: base, aeson, aeson-pretty, servant, servant-docs, string-conversions, text
+  build-depends: base, aeson, servant, servant-docs, string-conversions, text
   default-language: Haskell2010

--- a/servant-docs.cabal
+++ b/servant-docs.cabal
@@ -32,6 +32,7 @@ library
     , aeson-pretty < 0.8
     , bytestring
     , hashable
+    , http-media
     , lens
     , servant >= 0.2.1
     , string-conversions
@@ -46,5 +47,5 @@ executable greet-docs
   main-is: greet.hs
   hs-source-dirs: example
   ghc-options: -Wall
-  build-depends: base, aeson, servant, servant-docs, text
+  build-depends: base, aeson, aeson-pretty, servant, servant-docs, text
   default-language: Haskell2010

--- a/servant-docs.cabal
+++ b/servant-docs.cabal
@@ -45,5 +45,5 @@ executable greet-docs
   main-is: greet.hs
   hs-source-dirs: example
   ghc-options: -Wall
-  build-depends: base, aeson, aeson-pretty, servant, servant-docs, text
+  build-depends: base, aeson, aeson-pretty, servant, servant-docs, string-conversions, text
   default-language: Haskell2010

--- a/src/Servant/Docs.hs
+++ b/src/Servant/Docs.hs
@@ -462,7 +462,7 @@ sampleByteStrings
     -> [(Text, M.MediaType, ByteString)]
 sampleByteStrings ctypes@Proxy Proxy =
     let samples = toSamples :: [(Text, a)]
-        enc (t, s) = (\(m,b) -> (t,m,b)) <$> amr ctypes s
+        enc (t, s) = uncurry (t,,) <$> amr ctypes s
     in concatMap enc samples
 
 -- | The class that helps us automatically get documentation

--- a/src/Servant/Docs.hs
+++ b/src/Servant/Docs.hs
@@ -625,7 +625,7 @@ markdown api = unlines $
             <> [""]
 
         formatBody (m, b) =
-          "- Example: `" <> cs (M.mainType m <> "/" <> M.subType m) <> "`" :
+          "- Example: `" <> cs (show m) <> "`" :
           contentStr m b
 
         markdownForType mime_type =

--- a/src/Servant/Docs.hs
+++ b/src/Servant/Docs.hs
@@ -455,7 +455,7 @@ sampleByteString
     -> Proxy a
     -> [(M.MediaType, ByteString)]
 sampleByteString ctypes@Proxy Proxy =
-    maybe [] (amr ctypes) (toSample :: Maybe a)
+    maybe [] (allMimeRender ctypes) (toSample :: Maybe a)
 
 -- | Synthesise a list of sample values of a particular type, encoded in the
 -- specified media types.
@@ -466,7 +466,7 @@ sampleByteStrings
     -> [(Text, M.MediaType, ByteString)]
 sampleByteStrings ctypes@Proxy Proxy =
     let samples = toSamples :: [(Text, a)]
-        enc (t, s) = uncurry (t,,) <$> amr ctypes s
+        enc (t, s) = uncurry (t,,) <$> allMimeRender ctypes s
     in concatMap enc samples
 
 -- | Generate a list of 'MediaType' values describing the content types

--- a/src/Servant/Docs.hs
+++ b/src/Servant/Docs.hs
@@ -102,11 +102,11 @@
 -- > -- API specification
 -- > type TestApi =
 -- >        -- GET /hello/:name?capital={true, false}  returns a Greet as JSON
--- >        "hello" :> MatrixParam "lang" String :> Capture "name" Text :> QueryParam "capital" Bool :> Get Greet
+-- >        "hello" :> MatrixParam "lang" String :> Capture "name" Text :> QueryParam "capital" Bool :> Get '[JSON] Greet
 -- >
 -- >        -- POST /greet with a Greet as JSON in the request body,
 -- >        --             returns a Greet as JSON
--- >   :<|> "greet" :> ReqBody Greet :> Post Greet
+-- >   :<|> "greet" :> ReqBody '[JSON] Greet :> Post '[JSON] Greet
 -- >
 -- >        -- DELETE /greet/:greetid
 -- >   :<|> "greet" :> Capture "greetid" Text :> Delete
@@ -154,7 +154,7 @@ module Servant.Docs
   , module Data.Monoid
   ) where
 
-import Control.Lens hiding (Action)
+import Control.Lens
 import Data.Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Ord(comparing)
@@ -641,7 +641,7 @@ instance HasDocs Delete where
           action' = action & response.respBody .~ []
                            & response.respStatus .~ 204
 
-instance ToSample a => HasDocs (Get a) where
+instance ToSample a => HasDocs (Get cts a) where
   docsFor Proxy (endpoint, action) =
     single endpoint' action'
 
@@ -658,7 +658,7 @@ instance (KnownSymbol sym, HasDocs sublayout)
           action' = over headers (|> headername) action
           headername = pack $ symbolVal (Proxy :: Proxy sym)
 
-instance ToSample a => HasDocs (Post a) where
+instance ToSample a => HasDocs (Post cts a) where
   docsFor Proxy (endpoint, action) =
     single endpoint' action'
 
@@ -669,7 +669,7 @@ instance ToSample a => HasDocs (Post a) where
 
           p = Proxy :: Proxy a
 
-instance ToSample a => HasDocs (Put a) where
+instance ToSample a => HasDocs (Put cts a) where
   docsFor Proxy (endpoint, action) =
     single endpoint' action'
 
@@ -761,7 +761,7 @@ instance HasDocs Raw where
     single endpoint action
 
 instance (ToSample a, HasDocs sublayout)
-      => HasDocs (ReqBody a :> sublayout) where
+      => HasDocs (ReqBody cts a :> sublayout) where
 
   docsFor Proxy (endpoint, action) =
     docsFor sublayoutP (endpoint, action')

--- a/src/Servant/Docs.hs
+++ b/src/Servant/Docs.hs
@@ -477,16 +477,10 @@ class SupportedTypes (list :: [*]) where
 instance SupportedTypes '[] where
     supportedTypes Proxy = []
 
-instance (Accept ctype) => SupportedTypes '[ctype] where
-    supportedTypes Proxy = [ contentType (Proxy :: Proxy ctype) ]
-
-instance (Accept ctype, Accept ctype', SupportedTypes rest)
-        => SupportedTypes (ctype ': ctype' ': rest) where
-
+instance (Accept ctype, SupportedTypes rest) => SupportedTypes (ctype ': rest)
+  where
     supportedTypes Proxy =
-        [ contentType (Proxy :: Proxy ctype)
-        , contentType (Proxy :: Proxy ctype')
-        ] <> supportedTypes (Proxy :: Proxy rest)
+        contentType (Proxy :: Proxy ctype) : supportedTypes (Proxy :: Proxy rest)
 
 -- | The class that helps us automatically get documentation
 --   for GET parameters.

--- a/src/Servant/Docs.hs
+++ b/src/Servant/Docs.hs
@@ -462,8 +462,7 @@ sampleByteStrings
     -> [(Text, M.MediaType, ByteString)]
 sampleByteStrings ctypes@Proxy Proxy =
     let samples = toSamples :: [(Text, a)]
-        ext t (a,b) = (t,a,b)
-        enc (t, s) = ext t <$> amr ctypes s
+        enc (t, s) = (\(m,b) -> (t,m,b)) <$> amr ctypes s
     in concatMap enc samples
 
 -- | The class that helps us automatically get documentation


### PR DESCRIPTION
Extend servant-docs to support content types as implemented in the jkarni/content-types branches in the servant repo.

- Generated documentation lists supported content types for request and response bodies.
- Generated documentation includes sample request and response bodies encoded in supported content types.
- Example code updated to include content types.

This requires changes included in https://github.com/haskell-servant/servant/pull/9 to build.